### PR TITLE
Include php7.0-zip extension

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -61,6 +61,7 @@ RUN \
         php7.0-opcache \
         php7.0-xml \
         php7.0-odbc \
+        php7.0-zip \
         php-pear \
         libsasl2-dev
 


### PR DESCRIPTION
This extension seems to be present on our php5.6 box but isn't there on this one. Needed for tapioca and probably other apps too.
